### PR TITLE
loom-data v0.17.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jwt-decode": "^2.1.0",
     "leaflet": "^1.0.2",
     "lodash": "^4.17.4",
-    "loom-data": "^0.17.0",
+    "loom-data": "^0.17.2",
     "normalizr": "^3.1.0",
     "react": "^15.4.0",
     "react-bootstrap": "^0.30.7",


### PR DESCRIPTION
`loom-data v0.17.2` removes the Auth0 JWT token that was being added as a query param for file download URLs. I've tested this locally, and once the build goes out, I'll test staging as well to make sure file downloads are not broken.