### PR TITLE
Add Side Nav Link to Help

### DIFF
--- a/src/components/sidenav/SideNav.js
+++ b/src/components/sidenav/SideNav.js
@@ -45,7 +45,7 @@ class SideNav extends React.Component {
       <div className={styles.sideNavItem}>
         <a href={route} target='_blank'>
           <div className={styles.sideNavItemIcon}>
-            <FontAwesome name="fa fa-flag fa-2x" aria-hidden="true" />
+            <FontAwesome name="flag" size="2x"/>
           </div>
           <div className={styles.sideNavItemText}>{ text }</div>
         </a>


### PR DESCRIPTION
Added Side Nav Item 'Help' that opens a new tab to https://help.thedataloom.com/

Note - I'm in the process of finding a help icon that is free. That or we should pay before pushing to prod.