### PR TITLE
delete entity types and property types

### DIFF
--- a/src/views/Main/Schemas/Components/EntityType.js
+++ b/src/views/Main/Schemas/Components/EntityType.js
@@ -12,8 +12,8 @@ import styles from '../styles.module.css';
 
 export class EntityType extends React.Component {
   static propTypes = {
-    entityType: PropTypes.object,
-    idToPropertyTypes: PropTypes.object,
+    entityType: PropTypes.shape({}),
+    idToPropertyTypes: PropTypes.shape({}),
     updateFn: PropTypes.func
   }
 

--- a/src/views/Main/Schemas/Components/EntityType.js
+++ b/src/views/Main/Schemas/Components/EntityType.js
@@ -13,7 +13,8 @@ import styles from '../styles.module.css';
 export class EntityType extends React.Component {
   static propTypes = {
     entityType: PropTypes.object,
-    idToPropertyTypes: PropTypes.object
+    idToPropertyTypes: PropTypes.object,
+    updateFn: PropTypes.func
   }
 
   static contextTypes = {
@@ -106,6 +107,13 @@ export class EntityType extends React.Component {
     });
   }
 
+  deleteEntityType = () => {
+    EntityDataModelApi.deleteEntityType(this.props.entityType.id)
+    .then(() => {
+      this.props.updateFn();
+    });
+  }
+
   reorderCallback = (e, movedItem, itemsPreviousIndex, itemsNewIndex, reorderedArray) => {
     const orderedIds = reorderedArray.map((propertyType) => {
       return propertyType.id;
@@ -138,6 +146,15 @@ export class EntityType extends React.Component {
             onClick={() => {
               this.setState({ isReordering: !this.state.isReordering });
             }}>{buttonText}</Button>
+      </div>
+    );
+  }
+
+  renderDeleteButton = () => {
+    if (!this.context.isAdmin) return null;
+    return (
+      <div style={{ textAlign: 'center', margin: '10px 0' }}>
+        <Button bsStyle="danger" onClick={this.deleteEntityType}>Delete</Button>
       </div>
     );
   }
@@ -175,6 +192,7 @@ export class EntityType extends React.Component {
         <div className={styles.spacerMed} />
         {this.renderProperties()}
         {this.renderReorderButton()}
+        {this.renderDeleteButton()}
         <div className={styles.spacerBig} />
         <hr />
       </div>

--- a/src/views/Main/Schemas/Components/PropertyType.js
+++ b/src/views/Main/Schemas/Components/PropertyType.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { Button } from 'react-bootstrap';
 import { EntityDataModelApi } from 'loom-data';
 import InlineEditableControl from '../../../../components/controls/InlineEditableControl';
 import { PropertyTypePropType } from '../../../../containers/edm/EdmModel';
@@ -6,7 +7,8 @@ import styles from '../styles.module.css';
 
 export class PropertyType extends React.Component {
   static propTypes = {
-    propertyType: PropertyTypePropType.isRequired
+    propertyType: PropertyTypePropType.isRequired,
+    updateFn: PropTypes.func.isRequired
   };
 
   static contextTypes = {
@@ -65,6 +67,22 @@ export class PropertyType extends React.Component {
     });
   }
 
+  deletePropertyType = () => {
+    EntityDataModelApi.deletePropertyType(this.props.propertyType.id)
+    .then(() => {
+      this.props.updateFn();
+    });
+  }
+
+  renderDeleteButton = () => {
+    if (!this.context.isAdmin) return null;
+    return (
+      <div style={{ textAlign: 'center', margin: '10px 0' }}>
+        <Button bsStyle="danger" onClick={this.deletePropertyType}>Delete</Button>
+      </div>
+    );
+  }
+
   render() {
     const prop = this.props.propertyType;
     return (
@@ -95,6 +113,7 @@ export class PropertyType extends React.Component {
         <div className={styles.spacerSmall} />
         <div className={styles.italic}>datatype: {prop.datatype}</div>
         {this.renderPiiField(prop)}
+        {this.renderDeleteButton()}
         <div className={styles.spacerBig} />
         <hr />
       </div>

--- a/src/views/Main/Schemas/Components/PropertyTypeSearchResults.js
+++ b/src/views/Main/Schemas/Components/PropertyTypeSearchResults.js
@@ -5,7 +5,8 @@ import styles from '../styles.module.css';
 export default class PropertyTypeSearchResults extends React.Component {
 
   static propTypes = {
-    results: PropTypes.array
+    results: PropTypes.array,
+    onUpdate: PropTypes.func
   };
 
   constructor(props, context) {
@@ -25,6 +26,7 @@ export default class PropertyTypeSearchResults extends React.Component {
     const propertyTypeList = this.props.results.map((propertyType) => {
       return (<PropertyType
           key={propertyType.id}
+          updateFn={this.props.onUpdate}
           propertyType={propertyType} />);
     });
 


### PR DESCRIPTION
note: we should probably refactor the search entity types/property types endpoints to load the elements based on ids returned from elasticsearch instead of just passing the elasticsearch objects back directly. would be good to enforce consistency there, and also the delay in deleting from elasticsearch sometimes causes elements not to disappear after being deleted (until you refresh) -- we could add a hack to fix this on the frontend but I'm not sure it's worth being hacky since this is just convenience functionality for us right now.