### PR TITLE
add table listing queries for postgres and pervasive

### DIFF
--- a/src/containers/organizations/components/IntegrationConfigGenerator.js
+++ b/src/containers/organizations/components/IntegrationConfigGenerator.js
@@ -24,7 +24,7 @@ const InputRow = styled.div`
   flex-direction: column;
   align-items: center;
   font-family: 'Open Sans', sans-serif;
-  margin-top: 15px;
+  margin: 10px 0;
 
   div {
     font-size: 16px;
@@ -79,7 +79,16 @@ export default class IntegrationConfigGenerator extends React.Component {
   }
 
   getOnChange = field => ({ target }) => {
-    this.setState({ [field]: target.value })
+    this.setState({ [field]: target.value });
+  }
+
+  onSQLTypeChange = ({ target }) => {
+    const { port } = this.state;
+
+    this.setState({
+      dataSqlType: target.value,
+      port: target.value ? DATA_SQL_TYPES[target.value].defaultPort : port
+    });
   }
 
   isReadyToSubmit = () => {
@@ -109,23 +118,23 @@ export default class IntegrationConfigGenerator extends React.Component {
           <StyledInput value={server} onChange={this.getOnChange('server')} />
         </InputRow>
         <InputRow>
-          <div>Target Port</div>
-          <span>ex. PD database port</span>
-          <StyledInput value={port} onChange={this.getOnChange('port')} />
-        </InputRow>
-        <InputRow>
           <div>Target Database</div>
           <span>ex. PD SQL database name</span>
           <StyledInput value={dbName} onChange={this.getOnChange('dbName')} />
         </InputRow>
         <InputRow>
           <div>Target Database SQL Type</div>
-          <StyledSelect value={dataSqlType} onChange={this.getOnChange('dataSqlType')}>
+          <StyledSelect value={dataSqlType} onChange={this.onSQLTypeChange}>
             <option value="" />
             {
               Object.keys(DATA_SQL_TYPES).map(name => <option value={name}>{name}</option>)
             }
           </StyledSelect>
+        </InputRow>
+        <InputRow>
+          <div>Target Port</div>
+          <span>ex. PD database port</span>
+          <StyledInput value={port} onChange={this.getOnChange('port')} />
         </InputRow>
         <InfoButton disabled={!this.isReadyToSubmit()} onClick={this.onSubmit}>Export</InfoButton>
       </Container>

--- a/src/containers/organizations/utils/IntegrationYamlTemplate.js
+++ b/src/containers/organizations/utils/IntegrationYamlTemplate.js
@@ -8,6 +8,7 @@ const TEMPLATE_CONSTANTS = {
 
   // computed based on DATA_SQL_TYPE
   SQL_DRIVER_STRING: '<sqlDriverString>',
+  TABLE_LISTING_SQL: ''
 
   // computed based on organization
   ORG_ID: '<orgID>',
@@ -36,7 +37,7 @@ destinations:
 integrations:
   pdSQLDB:
     openLatticeDB:
-      - source: "<INSERT_SELECT_TABLES_STATEMENT_HERE>"
+      - source: "${TEMPLATE_CONSTANTS.TABLE_LISTING_SQL}"
         destination: ${TEMPLATE_CONSTANTS.ORG_NAME_SHORT}_data_Tables
         description: "${TEMPLATE_CONSTANTS.ORG_NAME_SHORT} table listing"
       - source: "select '( select * from ' || "TABLE_NAME" || ' ) ' || 'tbl_' || "TABLE_NAME" as query, "TABLE_NAME" as destination, 'gluttony'  as description from ${TEMPLATE_CONSTANTS.ORG_NAME_SHORT}_data_Tables;"

--- a/src/containers/organizations/utils/IntegrationYamlTemplate.js
+++ b/src/containers/organizations/utils/IntegrationYamlTemplate.js
@@ -8,7 +8,9 @@ const TEMPLATE_CONSTANTS = {
 
   // computed based on DATA_SQL_TYPE
   SQL_DRIVER_STRING: '<sqlDriverString>',
+  CONNECTION_SUFFIX_STRING: '<sqlConnSuffixString>',
   TABLE_LISTING_SQL: '<sqlTableString>',
+  DEFAULT_PORT: '<defaultPort>',
 
   // computed based on organization
   ORG_ID: '<orgID>',
@@ -23,7 +25,7 @@ const TEMPLATE =
 description: "Copying over data from ${TEMPLATE_CONSTANTS.ORG_NAME} into OpenLattice server"
 datasources:
 - name: pdSQLDB
-  url: "jdbc:${TEMPLATE_CONSTANTS.DATA_SQL_TYPE}://${TEMPLATE_CONSTANTS.TARGET_SERVER}:${TEMPLATE_CONSTANTS.TARGET_PORT}/${TEMPLATE_CONSTANTS.TARGET_DB_NAME}"
+  url: "jdbc:${TEMPLATE_CONSTANTS.DATA_SQL_TYPE}://${TEMPLATE_CONSTANTS.TARGET_SERVER}:${TEMPLATE_CONSTANTS.TARGET_PORT}/${TEMPLATE_CONSTANTS.TARGET_DB_NAME}${TEMPLATE_CONSTANTS.CONNECTION_SUFFIX_STRING}"
   username: "<INSERT_USERNAME_HERE>"
   password: "<INSERT_PASSWORD_HERE>"
   driver: ${TEMPLATE_CONSTANTS.SQL_DRIVER_STRING}
@@ -37,10 +39,10 @@ destinations:
 integrations:
   pdSQLDB:
     openLatticeDB:
-      - source: "${TEMPLATE_CONSTANTS.TABLE_LISTING_SQL}"
+      - source: " ( ${TEMPLATE_CONSTANTS.TABLE_LISTING_SQL} ) dh "
         destination: ${TEMPLATE_CONSTANTS.ORG_NAME_SHORT}_data_Tables
         description: "${TEMPLATE_CONSTANTS.ORG_NAME_SHORT} table listing"
-      - source: "select '( select * from ' || "TABLE_NAME" || ' ) ' || 'tbl_' || "TABLE_NAME" as query, "TABLE_NAME" as destination, 'gluttony'  as description from ${TEMPLATE_CONSTANTS.ORG_NAME_SHORT}_data_Tables;"
+      - source: "select '( select * from ' || \\"TABLE_NAME\\" || ' ) ' || 'tbl_' || \\"TABLE_NAME\\" as query, \\"TABLE_NAME\\" as destination, 'gluttony'  as description from ${TEMPLATE_CONSTANTS.ORG_NAME_SHORT}_data_Tables;"
         destination: "dst"
         description: "gluttony"
         gluttony: true

--- a/src/containers/organizations/utils/IntegrationYamlTemplate.js
+++ b/src/containers/organizations/utils/IntegrationYamlTemplate.js
@@ -8,7 +8,7 @@ const TEMPLATE_CONSTANTS = {
 
   // computed based on DATA_SQL_TYPE
   SQL_DRIVER_STRING: '<sqlDriverString>',
-  TABLE_LISTING_SQL: ''
+  TABLE_LISTING_SQL: '<sqlTableString>',
 
   // computed based on organization
   ORG_ID: '<orgID>',

--- a/src/containers/organizations/utils/IntegrationYamlUtils.js
+++ b/src/containers/organizations/utils/IntegrationYamlUtils.js
@@ -6,122 +6,170 @@ export const DATA_SQL_TYPES = {
   'Pervasive SQL': {
     driver: 'com.pervasive.jdbc.v2.Driver',
     connectionString: 'pervasive',
-    tablesSql: '( SELECT * FROM MasterNameVitals ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM MasterNameVitals',
+    defaultPort: 0
   },
   'IBM DB2': {
     driver: 'COM.ibm.db2.jdbc.app.DB2Driver',
     connectionString: 'db2',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'JDBC-ODBC Bridge': {
     driver: 'sun.jdbc.odbc.JdbcOdbcDriver',
     connectionString: 'odbc',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Microsoft SQL Server': {
     driver: 'weblogic.jdbc.mssqlserver4.Driver',
     connectionString: 'weblogic',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'PointBase Embedded Server': {
     driver: 'com.pointbase.jdbc.jdbcUniversalDriver',
     connectionString: 'pointbase',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Cloudscape': {
     driver: 'COM.cloudscape.core.JDBCDriver',
     connectionString: 'cloudscape',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Cloudscape RMI': {
     driver: 'RmiJdbc.RJDriver',
     connectionString: 'rmi',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Firebird (JCA/JDBC Driver)': {
     driver: 'org.firebirdsql.jdbc.FBDriver',
     connectionString: 'firebirdsql',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'IDS Server': {
     driver: 'ids.sql.IDSDriver',
     connectionString: 'ids',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Informix Dynamic Server': {
     driver: 'com.informix.jdbc.IfxDriver',
     connectionString: 'informix-sqli',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: ':informixserver=<serverNameHere>;DELIMIDENT=Y',
+    tablesSql: 'INFO TABLES',
+    defaultPort: 0
   },
   'InstantDB (v3.13 and earlier)': {
     driver: 'jdbc.idbDriver',
     connectionString: 'idb',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'InstantDB (v3.14 and later)': {
     driver: 'org.enhydra.instantdb.jdbc.idbDriver',
     connectionString: 'idb',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Interbase (InterClient Driver)': {
     driver: 'interbase.interclient.Driver',
     connectionString: 'interbase',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Hypersonic SQL (v1.2 and earlier)': {
     driver: 'hSql.hDriver',
     connectionString: 'HypersonicSQL',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Hypersonic SQL (v1.3 and later)': {
     driver: 'org.hsql.jdbcDriver',
     connectionString: 'HypersonicSQL',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Microsoft SQL Server (JTurbo Driver)': {
     driver: 'com.ashna.jturbo.driver.Driver',
     connectionString: 'JTurbo',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Microsoft SQL Server (Sprinta Driver)': {
     driver: 'com.inet.tds.TdsDriver',
     connectionString: 'inetdae',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Microsoft SQL Server 2000 (Microsoft Driver)': {
     driver: 'com.microsoft.jdbc.sqlserver.SQLServerDriver',
     connectionString: 'microsoft',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'MySQL (MM.MySQL Driver)': {
     driver: 'org.gjt.mm.mysql.Driver',
     connectionString: 'mysql',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   Oracle: {
     driver: 'oracle.jdbc.driver.OracleDriver',
     connectionString: 'oracle',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'PostgreSQL (v6.5 and earlier)': {
     driver: 'postgresql.Driver',
     connectionString: 'postgresql',
-    tablesSql: '( SELECT * FROM pg_catalog.pg_tables ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM pg_catalog.pg_tables',
+    defaultPort: 5432
   },
   'PostgreSQL (v7.0 and later)': {
     driver: 'org.postgresql.Driver',
     connectionString: 'postgresql',
-    tablesSql: '( SELECT * FROM pg_catalog.pg_tables ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM pg_catalog.pg_tables',
+    defaultPort: 5432
   },
   'Sybase (jConnect 4.2 and earlier)': {
     driver: 'com.sybase.jdbc.SybDriver',
     connectionString: 'sybase',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   },
   'Sybase (jConnect 5.2)': {
     driver: 'com.sybase.jdbc2.jdbc.SybDriver',
     connectionString: 'sybase',
-    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
   }
 };
 
@@ -135,12 +183,14 @@ export const exportTemplate = ({
   orgUsername,
   orgPassword
 }) => {
-  const { driver, connectionString, tablesSql } = DATA_SQL_TYPES[dataSqlType];
+  const { driver, connectionString, connectionSuffixString, tablesSql, defaultPort } = DATA_SQL_TYPES[dataSqlType];
   const orgIdShort = `org_${orgId.replace(/-/g, '')}`;
   const orgNameShort = orgName.replace(/[^a-zA-Z0-9]/g, '');
 
   const fieldMappings = {
     [TEMPLATE_CONSTANTS.DATA_SQL_TYPE]: connectionString,
+    [TEMPLATE_CONSTANTS.DEFAULT_PORT]: defaultPort,
+    [TEMPLATE_CONSTANTS.CONNECTION_SUFFIX_STRING]: connectionSuffixString,
     [TEMPLATE_CONSTANTS.SQL_DRIVER_STRING]: driver,
     [TEMPLATE_CONSTANTS.TABLE_LISTING_SQL]: tablesSql,
     [TEMPLATE_CONSTANTS.TARGET_SERVER]: server,

--- a/src/containers/organizations/utils/IntegrationYamlUtils.js
+++ b/src/containers/organizations/utils/IntegrationYamlUtils.js
@@ -71,7 +71,7 @@ export const DATA_SQL_TYPES = {
     connectionString: 'informix-sqli',
     connectionSuffixString: ':informixserver=<serverNameHere>;DELIMIDENT=Y',
     tablesSql: 'INFO TABLES',
-    defaultPort: 0
+    defaultPort: 9088
   },
   'InstantDB (v3.13 and earlier)': {
     driver: 'jdbc.idbDriver',
@@ -157,19 +157,61 @@ export const DATA_SQL_TYPES = {
     tablesSql: 'SELECT * FROM pg_catalog.pg_tables',
     defaultPort: 5432
   },
+  SnappyData: {
+    driver: 'com.pivotal.gemfirexd.jdbc.ClientDriver',
+    connectionString: 'snappydata',
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
+  },
+  SqlBase: {
+    driver: 'jdbc.gupta.sqlbase.SqlbaseDriver',
+    connectionString: 'sqlbase',
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 0
+  },
   'Sybase (jConnect 4.2 and earlier)': {
     driver: 'com.sybase.jdbc.SybDriver',
     connectionString: 'sybase',
     connectionSuffixString: '',
     tablesSql: 'SELECT * FROM <metaTableGoesHere>',
-    defaultPort: 0
+    defaultPort: 5000
   },
   'Sybase (jConnect 5.2)': {
     driver: 'com.sybase.jdbc2.jdbc.SybDriver',
     connectionString: 'sybase',
     connectionSuffixString: '',
     tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 5000
+  },
+  'Sybase ASE': {
+    driver: 'net.sourceforge.jtds.jdbc.Driver',
+    connectionString: 'sybase:Tds',
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 5000
+  },
+  'Sybase SqlAnywhere': {
+    driver: 'com.sybase.jdbc3.jdbc.SybDriver',
+    connectionString: 'sybase:Tds',
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 5000
+  },
+  Transbase: {
+    driver: 'transbase.jdbc.Driver',
+    connectionString: 'transbase',
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
     defaultPort: 0
+  },
+  Vertica: {
+    driver: 'com.vertica.jdbc.Driver',
+    connectionString: 'vertica',
+    connectionSuffixString: '',
+    tablesSql: 'SELECT * FROM <metaTableGoesHere>',
+    defaultPort: 5433
   }
 };
 

--- a/src/containers/organizations/utils/IntegrationYamlUtils.js
+++ b/src/containers/organizations/utils/IntegrationYamlUtils.js
@@ -3,12 +3,12 @@ import FileSaver from 'file-saver';
 import { TEMPLATE, TEMPLATE_CONSTANTS } from './IntegrationYamlTemplate';
 
 export const DATA_SQL_TYPES = {
-  'Pervasive SQL': {
+  'IMC/Pervasive SQL': {
     driver: 'com.pervasive.jdbc.v2.Driver',
     connectionString: 'pervasive',
-    connectionSuffixString: '',
+    connectionSuffixString: '?transport=tcp',
     tablesSql: 'SELECT * FROM MasterNameVitals',
-    defaultPort: 0
+    defaultPort: 1583
   },
   'IBM DB2': {
     driver: 'COM.ibm.db2.jdbc.app.DB2Driver',
@@ -66,7 +66,7 @@ export const DATA_SQL_TYPES = {
     tablesSql: 'SELECT * FROM <metaTableGoesHere>',
     defaultPort: 0
   },
-  'Informix Dynamic Server': {
+  'QED/Informix Dynamic Server': {
     driver: 'com.informix.jdbc.IfxDriver',
     connectionString: 'informix-sqli',
     connectionSuffixString: ':informixserver=<serverNameHere>;DELIMIDENT=Y',

--- a/src/containers/organizations/utils/IntegrationYamlUtils.js
+++ b/src/containers/organizations/utils/IntegrationYamlUtils.js
@@ -135,7 +135,7 @@ export const exportTemplate = ({
   orgUsername,
   orgPassword
 }) => {
-  const { driver, connectionString } = DATA_SQL_TYPES[dataSqlType];
+  const { driver, connectionString, tablesSql } = DATA_SQL_TYPES[dataSqlType];
   const orgIdShort = `org_${orgId.replace(/-/g, '')}`;
   const orgNameShort = orgName.replace(/[^a-zA-Z0-9]/g, '');
 

--- a/src/containers/organizations/utils/IntegrationYamlUtils.js
+++ b/src/containers/organizations/utils/IntegrationYamlUtils.js
@@ -5,99 +5,123 @@ import { TEMPLATE, TEMPLATE_CONSTANTS } from './IntegrationYamlTemplate';
 export const DATA_SQL_TYPES = {
   'Pervasive SQL': {
     driver: 'com.pervasive.jdbc.v2.Driver',
-    connectionString: 'pervasive'
+    connectionString: 'pervasive',
+    tablesSql: '( SELECT * FROM MasterNameVitals ) dh'
   },
   'IBM DB2': {
     driver: 'COM.ibm.db2.jdbc.app.DB2Driver',
-    connectionString: 'db2'
+    connectionString: 'db2',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'JDBC-ODBC Bridge': {
     driver: 'sun.jdbc.odbc.JdbcOdbcDriver',
-    connectionString: 'odbc'
+    connectionString: 'odbc',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Microsoft SQL Server': {
     driver: 'weblogic.jdbc.mssqlserver4.Driver',
-    connectionString: 'weblogic'
+    connectionString: 'weblogic',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'PointBase Embedded Server': {
     driver: 'com.pointbase.jdbc.jdbcUniversalDriver',
-    connectionString: 'pointbase'
+    connectionString: 'pointbase',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Cloudscape': {
     driver: 'COM.cloudscape.core.JDBCDriver',
-    connectionString: 'cloudscape'
+    connectionString: 'cloudscape',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Cloudscape RMI': {
     driver: 'RmiJdbc.RJDriver',
-    connectionString: 'rmi'
+    connectionString: 'rmi',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Firebird (JCA/JDBC Driver)': {
     driver: 'org.firebirdsql.jdbc.FBDriver',
-    connectionString: 'firebirdsql'
+    connectionString: 'firebirdsql',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'IDS Server': {
     driver: 'ids.sql.IDSDriver',
-    connectionString: 'ids'
+    connectionString: 'ids',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Informix Dynamic Server': {
     driver: 'com.informix.jdbc.IfxDriver',
-    connectionString: 'informix-sqli'
+    connectionString: 'informix-sqli',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'InstantDB (v3.13 and earlier)': {
     driver: 'jdbc.idbDriver',
-    connectionString: 'idb'
+    connectionString: 'idb',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'InstantDB (v3.14 and later)': {
     driver: 'org.enhydra.instantdb.jdbc.idbDriver',
-    connectionString: 'idb'
+    connectionString: 'idb',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Interbase (InterClient Driver)': {
     driver: 'interbase.interclient.Driver',
-    connectionString: 'interbase'
+    connectionString: 'interbase',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Hypersonic SQL (v1.2 and earlier)': {
     driver: 'hSql.hDriver',
-    connectionString: 'HypersonicSQL'
+    connectionString: 'HypersonicSQL',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Hypersonic SQL (v1.3 and later)': {
     driver: 'org.hsql.jdbcDriver',
-    connectionString: 'HypersonicSQL'
+    connectionString: 'HypersonicSQL',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Microsoft SQL Server (JTurbo Driver)': {
     driver: 'com.ashna.jturbo.driver.Driver',
-    connectionString: 'JTurbo'
+    connectionString: 'JTurbo',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Microsoft SQL Server (Sprinta Driver)': {
     driver: 'com.inet.tds.TdsDriver',
-    connectionString: 'inetdae'
+    connectionString: 'inetdae',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Microsoft SQL Server 2000 (Microsoft Driver)': {
     driver: 'com.microsoft.jdbc.sqlserver.SQLServerDriver',
-    connectionString: 'microsoft'
+    connectionString: 'microsoft',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'MySQL (MM.MySQL Driver)': {
     driver: 'org.gjt.mm.mysql.Driver',
-    connectionString: 'mysql'
+    connectionString: 'mysql',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   Oracle: {
     driver: 'oracle.jdbc.driver.OracleDriver',
-    connectionString: 'oracle'
+    connectionString: 'oracle',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'PostgreSQL (v6.5 and earlier)': {
     driver: 'postgresql.Driver',
-    connectionString: 'postgresql'
+    connectionString: 'postgresql',
+    tablesSql: '( SELECT * FROM pg_catalog.pg_tables ) dh'
   },
   'PostgreSQL (v7.0 and later)': {
     driver: 'org.postgresql.Driver',
-    connectionString: 'postgresql'
+    connectionString: 'postgresql',
+    tablesSql: '( SELECT * FROM pg_catalog.pg_tables ) dh'
   },
   'Sybase (jConnect 4.2 and earlier)': {
     driver: 'com.sybase.jdbc.SybDriver',
-    connectionString: 'sybase'
+    connectionString: 'sybase',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   },
   'Sybase (jConnect 5.2)': {
     driver: 'com.sybase.jdbc2.jdbc.SybDriver',
-    connectionString: 'sybase'
+    connectionString: 'sybase',
+    tablesSql: '( SELECT * FROM <metaTableGoesHere> ) dh'
   }
 };
 
@@ -118,6 +142,7 @@ export const exportTemplate = ({
   const fieldMappings = {
     [TEMPLATE_CONSTANTS.DATA_SQL_TYPE]: connectionString,
     [TEMPLATE_CONSTANTS.SQL_DRIVER_STRING]: driver,
+    [TEMPLATE_CONSTANTS.TABLE_LISTING_SQL]: tablesSql,
     [TEMPLATE_CONSTANTS.TARGET_SERVER]: server,
     [TEMPLATE_CONSTANTS.TARGET_PORT]: port,
     [TEMPLATE_CONSTANTS.TARGET_DB_NAME]: dbName,


### PR DESCRIPTION
This PR:
- adds a default select statement to populate the query that generates table names for the datasources that we've used it on prior (pervasive and postgres)
- Escapes quotes in gluttony string
- Include subquery parentheses and table name
- Add connection suffix
- Add default ports